### PR TITLE
chore(deps): bump golang from 1.20.6-alpine to 1.21.5-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yarn install --immutable
 RUN yarn build
 RUN yarn cache clean
 
-FROM golang:1.20.6-alpine AS go_builder
+FROM golang:1.21.5-alpine AS go_builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps golang from 1.20.6-alpine to 1.21.5-alpine.

---
updated-dependencies:
- dependency-name: golang dependency-type: direct:production update-type: version-update:semver-minor ...